### PR TITLE
remove unused unload event listener for browser.xul

### DIFF
--- a/firefox/chrome/content/browser.js
+++ b/firefox/chrome/content/browser.js
@@ -25,7 +25,6 @@ var GreasefireController = {
                   .getService(Ci.gfIGreasefireService);
 
     window.addEventListener("load", this, false);
-    window.addEventListener("unload", this, false);
   },
 
   _newLocation: function(aURI) {


### PR DESCRIPTION
It looks to me like this `window.unload` event listener isn't used for anything.
