### PR TITLE
Remove unused Progress event listeners (made optional in Gecko 2)

### DIFF
--- a/firefox/chrome/content/browser.js
+++ b/firefox/chrome/content/browser.js
@@ -122,22 +122,14 @@ var GreasefireController = {
     if (aEvent.type == "load") {
       this._setupMenu();
 
-      gBrowser.addProgressListener(this,
-                                   Ci.nsIWebProgress.NOTIFY_STATE_DOCUMENT);
+      gBrowser.addProgressListener(this, Ci.nsIWebProgress.NOTIFY_LOCATION);
     }
   },
 
   // nsIWebProgress
-  onLocationChange: function(aProgress, aRequest, aURI)
-  {
+  onLocationChange: function(aProgress, aRequest, aURI) {
     this._newLocation(aURI);
-  },
-
-  onStateChange: function() {},
-  onProgressChange: function() {},
-  onStatusChange: function() {},
-  onSecurityChange: function() {},
-  onLinkIconAvailable: function() {}
+  }
 }
 
 GreasefireController.init();


### PR DESCRIPTION
The code removed in the attached patch is no longer needed as of Gecko 2 https://developer.mozilla.org/en/Code_snippets/Progress_Listeners
