### PR TITLE
(See issue #68)

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,34 +1,52 @@
 #!/bin/sh
 
+cleanup () {
+  [ -n "$TMPDIR" ] && [ -e "$TMPDIR" ] && rm -rf "$TMPDIR"
+}
+
+die () {
+  [ -n "$1" ] && echo $1 >&2
+  cleanup
+  exit 1
+}
+
+WORKDIR='/Users/steve/greasefire'
+TMPDIR="$WORKDIR/tmp"
+SCRAPERDIR="$WORKDIR/greasefire/java/greasefire-scraper"
+INDEXES='skrul.com/projects/greasefire/indexes'
+
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 DEST="index_$DATE.jar"
 
 # Download scripts
-cd /Users/steve/greasefire
-java -jar greasefire/java/greasefire-scraper/downloadscripts.jar scripts $1
+cd "$WORKDIR" || die
+java -jar "$SCRAPERDIR/downloadscripts.jar" scripts "$1" || die
 
-# Generate indexes into tmp
-mkdir tmp
-java -Xmx512m -jar greasefire/java/greasefire-scraper/generateindex.jar scripts tmp
+# Generate indexes into TMPDIR
+mkdir "$TMPDIR" || die
+java -Xmx512m -jar "$SCRAPERDIR/generateindex.jar" scripts "$TMPDIR" || die
 
 # Jar up indexes
-cd tmp
+cd "$TMPDIR" || die
 echo "[indexes]" > info.ini
 echo "date=$DATE" >> info.ini
-jar cvfM $DEST include.dat exclude.dat scripts.db info.ini
-mkdir $DATE
-cp include.png exclude.png $DATE
+jar cvfM "$DEST" include.dat exclude.dat scripts.db info.ini || die
+
+mkdir "$DATE" || die
+cp include.png exclude.png "$DATE" || die
+
+[ -n "$DEST" -a -f "./$DEST" ] || die "no $DEST file"
+[ -n "$DATE" -a -d "./$DATE" ] || die "no $DATE directory"
 
 # Copy indexes to skrul.com
-scp -r ./$DEST ./$DATE skrul@skrul.com:skrul.com/projects/greasefire/indexes
-
-# Clean up tmp
-cd ..
-rm -r tmp
+scp -r ./"$DEST" ./"$DATE" \
+   skrul@skrul.com:skrul.com/projects/greasefire/indexes || die
 
 # Update latest file on skrul.com
-ssh skrul@skrul.com "echo $DATE > skrul.com/projects/greasefire/indexes/latest"
+ssh skrul@skrul.com "echo $DATE > "'"'"$INDEXES"'"'"/latest"
 
 # Delete indexes older than a week
-ssh skrul@skrul.com "find skrul.com/projects/greasefire/indexes/index_* -type f -mtime 7 -exec rm {} \;"
+ssh skrul@skrul.com "find "'"'"$INDEXES"'"'"/index_* -type f -mtime 7 -exec rm {} \;"
 
+# # Clean up TMPDIR
+cleanup


### PR DESCRIPTION
This version attempts to ensure that the updating of skrul.com/projects/greasefire/indexes/latest file does not happen unless the preceding steps succeed.

I explicitly avoided setting errexit for this, since this is unreliable.

I used double-quotes extensively to wrap variable names, in the spirit of defensive programming (since in the future those variables may contain strings that include, e.g., whitespace).
